### PR TITLE
Fix rosbag recorder

### DIFF
--- a/rosbagrecorder.h
+++ b/rosbagrecorder.h
@@ -16,7 +16,7 @@ public:
     ~RosbagRecorder();
 
 public slots:
-    void startRecording(const QStringList &topics);
+    void startRecording(const QString &bagName, const QStringList &topics);
     void stopRecording();
 
 signals:
@@ -29,7 +29,8 @@ private slots:
     void onReadyReadStandardOutput();
 
 private:
-    std::unique_ptr<QProcess> *rosbagProc;
+    bool killProcessGroup(qint64 pid, int sig, int waitMs);
+    std::unique_ptr<QProcess> rosbagProc_;
 };
 
 #endif // ROSBAGRECORDER_H


### PR DESCRIPTION
## Summary
- correct rosbag recorder header definitions
- rewrite rosbagrecorder.cpp with a working implementation

## Testing
- `g++ -std=c++14 -fPIC -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/include/x86_64-linux-gnu/qt5/QtWidgets -c rosbagrecorder.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6881dbcb6b30832cb7d61079b644bef1