### PR TITLE
Fix recording logic and missing variables

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -14,6 +14,7 @@
 #include <csignal>
 #include <unordered_map>
 #include <QString>
+#include <QStringList>
 #include <QtGlobal> 
 #include <QLabel>
 #include "diagnostics_monitor.h"
@@ -69,6 +70,7 @@ private:
     std::unordered_map<QString, std::unique_ptr<QProcess>, QStringHash> drivers_; 
     std::unique_ptr<DiagnosticsMonitor> diag_monitor_;
     QTimer* rosTimer_;
-    std::unique_ptr<RosbagRecorder> recorder_; 
+    std::unique_ptr<RosbagRecorder> recorder_;
+    QStringList recordTopics_;
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- track recording topic selection in `MainWindow`
- correct recording setup connections
- fix checkbox slots
- include missing system headers

## Testing
- `g++ -c mainwindow.cpp` *(fails: QMainWindow not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f18d6678832c88ce9d6feb97c275