### PR TITLE
Add page navigation buttons

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -46,6 +46,13 @@ MainWindow::MainWindow(QWidget *parent)
 {
     ui->setupUi(this);
 
+    connect(ui->nextPageButton, &QPushButton::clicked, this, &MainWindow::showNextPage);
+    connect(ui->prevPageButton, &QPushButton::clicked, this, &MainWindow::showPrevPage);
+    ui->prevPageButton->setEnabled(false);
+    if (ui->stackedWidget->count() <= 1) {
+        ui->nextPageButton->setEnabled(false);
+    }
+
 #ifdef HH_ENABLE_RVIZ
     rviz_widget_ = std::make_unique<RvizWidget>(QString::fromUtf8(kRvizConfig), this);
     auto rvizLayout = new QVBoxLayout(ui->rvizContainer);
@@ -390,4 +397,22 @@ void MainWindow::onRecordingStarted() {
 
 void MainWindow::onRecordingStopped() {
     ui->recordStatus->setText("OFF");
+}
+
+void MainWindow::showNextPage() {
+    int index = ui->stackedWidget->currentIndex();
+    if (index < ui->stackedWidget->count() - 1) {
+        ui->stackedWidget->setCurrentIndex(index + 1);
+    }
+    ui->prevPageButton->setEnabled(true);
+    ui->nextPageButton->setEnabled(ui->stackedWidget->currentIndex() < ui->stackedWidget->count() - 1);
+}
+
+void MainWindow::showPrevPage() {
+    int index = ui->stackedWidget->currentIndex();
+    if (index > 0) {
+        ui->stackedWidget->setCurrentIndex(index - 1);
+    }
+    ui->nextPageButton->setEnabled(true);
+    ui->prevPageButton->setEnabled(ui->stackedWidget->currentIndex() > 0);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -55,9 +55,11 @@ private slots:
     void onDiagStatus(const QString&, int, const QString&, const QString&);
 
     void onRecordingStarted();
-    void onRecordingStopped(); 
+    void onRecordingStopped();
     void on_cameraCheckbox_stateChanged(int checked);
     void on_lidarCheckbox_stateChanged(int checked);
+    void showNextPage();
+    void showPrevPage();
 private:
     std::unique_ptr<QProcess> createDriverProcess(const QString& scriptPath,
                                                   const QString& key); 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -14,7 +14,7 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout_8">
+   <layout class="QVBoxLayout" name="verticalLayout_8">
     <property name="spacing">
      <number>0</number>
     </property>
@@ -360,6 +360,37 @@
        </layout>
       </widget>
      </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="pageButtonsLayout">
+      <item>
+       <widget class="QPushButton" name="prevPageButton">
+        <property name="text">
+         <string>Previous</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="navigationSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="nextPageButton">
+        <property name="text">
+         <string>Next</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
## Summary
- add Previous/Next buttons below stacked widget to switch pages
- wire buttons to update stacked widget index

## Testing
- `apt-get install -y qtbase5-dev`
- `qmake HandheldScanner.pro` *(fails: roscpp development package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907a6daac0832cb8b57a792b688ff2