### PR TITLE
Manage roscore lifecycle from UI

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -62,13 +62,15 @@ private slots:
     void showPrevPage();
 private:
     std::unique_ptr<QProcess> createDriverProcess(const QString& scriptPath,
-                                                  const QString& key); 
-    void shutdownProcess(const QString& key); 
+                                                  const QString& key);
+    void shutdownProcess(const QString& key);
     bool killProcessGroup(qint64 pid, int sig, int waitMs); // qint64 is a qt's aliws for int64
+    void startRoscore();
+    void stopRoscore();
     void startCamera();
     void stopCamera();
     void startLidar();
-    void stopLidar(); 
+    void stopLidar();
     void startWatchdog();
     void stopWatchdog();
     void handleProcessCrash(const QString& crashedProc);


### PR DESCRIPTION
## Summary
- launch roscore when starting drivers and ensure it is stopped with the rest of the drivers
- expose roscore lifecycle through new start/stop helpers and status updates to the `roscoreStatus` label
- handle roscore crash/completion to keep UI status accurate

## Testing
- `qmake HandheldScanner.pro` *(fails: roscpp development package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689082f74c1c832ca91d19c722bcd74d