### PR TITLE
Fix recorder API and registry initialization for build compatibility

### DIFF
--- a/process_config.h
+++ b/process_config.h
@@ -50,63 +50,67 @@ private:
 // Initialize all process definitions
 inline void initializeProcesses() {
     auto& registry = ProcessRegistry::instance();
-    
+
     // Roscore
     registry.registerProcess({
-        .key = "roscore",
-        .name = "ROS Core",
-        .executable = "/usr/bin/roscore",
-        .arguments = {},
-        .canStart = [](const auto&) { return true; },  // Always can start
-        .startupDelayMs = 1000,
-        .critical = true
+        "roscore",
+        "ROS Core",
+        "/usr/bin/roscore",
+        {},
+        [](const auto&) { return true; },  // Always can start
+        1000,
+        true
     });
-    
+
     // Camera
     registry.registerProcess({
-        .key = "camera",
-        .name = "Camera Driver",
-        .executable = "/home/kodifly/setup_scripts/camera_setup.sh",
-        .arguments = {},
-        .canStart = [](const auto& running) { 
-            return running.count("roscore") > 0; 
+        "camera",
+        "Camera Driver",
+        "/home/kodifly/setup_scripts/camera_setup.sh",
+        {},
+        [](const auto& running) {
+            return running.count("roscore") > 0;
         },
-        .critical = false
+        0,
+        false
     });
-    
+
     // Lidar
     registry.registerProcess({
-        .key = "lidar",
-        .name = "Lidar Driver",
-        .executable = "/home/kodifly/setup_scripts/lidar_setup.sh",
-        .arguments = {},
-        .canStart = [](const auto& running) { 
-            return running.count("roscore") > 0; 
+        "lidar",
+        "Lidar Driver",
+        "/home/kodifly/setup_scripts/lidar_setup.sh",
+        {},
+        [](const auto& running) {
+            return running.count("roscore") > 0;
         },
-        .critical = false
+        0,
+        false
     });
-    
+
     // SLAM
     registry.registerProcess({
-        .key = "slam",
-        .name = "SLAM",
-        .executable = "/home/kodifly/setup_scripts/start_slam.sh",
-        .arguments = {},
-        .canStart = [](const auto& running) { 
-            return running.count("camera") > 0 && running.count("lidar") > 0; 
+        "slam",
+        "SLAM",
+        "/home/kodifly/setup_scripts/start_slam.sh",
+        {},
+        [](const auto& running) {
+            return running.count("camera") > 0 && running.count("lidar") > 0;
         },
-        .critical = false
+        0,
+        false
     });
-    
+
     // Watchdog
     registry.registerProcess({
-        .key = "watchdog",
-        .name = "Watchdog",
-        .executable = "/home/kodifly/setup_scripts/watchdog_setup.sh",
-        .arguments = {},
-        .canStart = [](const auto& running) { 
-            return running.count("roscore") > 0; 
+        "watchdog",
+        "Watchdog",
+        "/home/kodifly/setup_scripts/watchdog_setup.sh",
+        {},
+        [](const auto& running) {
+            return running.count("roscore") > 0;
         },
-        .critical = false
+        0,
+        false
     });
 }

--- a/rosbagrecorder.cpp
+++ b/rosbagrecorder.cpp
@@ -24,7 +24,7 @@ RosbagRecorder::~RosbagRecorder()
 
 
 void RosbagRecorder::startRecording(const QString &bagName,
-                                    const QSet<QString> &topics)
+                                    const QStringList &topics)
 {
     if (rosbagProc_) {
         qWarning() << "rosbag recorder already running";
@@ -36,11 +36,9 @@ void RosbagRecorder::startRecording(const QString &bagName,
     rosbagProc_->setWorkingDirectory(QDir::homePath() + "/rosbags");
     qDebug() << "Directory set to:" << rosbagProc_->workingDirectory();
 
-    QStringList topicList = topics.values();
-
     const QString program("/usr/bin/setsid");
     QString cmd = QStringLiteral("exec rosbag record -O %1 --lz4 --tcpnodelay %2")
-                       .arg(bagName, topicList.join(' '));
+                       .arg(bagName, topics.join(' '));
     const QStringList args{"/bin/bash", "-c", cmd};
  
 
@@ -57,8 +55,6 @@ void RosbagRecorder::startRecording(const QString &bagName,
 
     rosbagProc_->start(program, args);
     if (!rosbagProc_->waitForStarted()) {
-        QMessageBox::critical(nullptr, tr("Failed to start"),
-                              tr("rosbag record could not be launched"));
         const QString err = tr("rosbag record could not be launched");
         QMessageBox::critical(nullptr, tr("Failed to start"), err);
         emit recordingError(err);

--- a/rosbagrecorder.h
+++ b/rosbagrecorder.h
@@ -17,7 +17,7 @@ public:
     bool isRecording() const { return isRecording_; }
 
 public slots:
-    void startRecording(const QString &bagName, const QSet<QString> &topics);
+    void startRecording(const QString &bagName, const QStringList &topics);
     void stopRecording();
 
 signals:


### PR DESCRIPTION
## Summary
- Align RosbagRecorder API with ScannerController by using `QStringList` topics and simplify error handling
- Replace C++20 designated initializers with aggregate initialization in process registry

## Testing
- `qmake HandheldScanner.pro` *(fails: roscpp development package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68942ff6b060832cb63fd42584a64900